### PR TITLE
test: 添加后端 API 集成测试与前端 Playwright E2E 测试

### DIFF
--- a/backend/tests/test_api_e2e.py
+++ b/backend/tests/test_api_e2e.py
@@ -1,0 +1,446 @@
+"""
+API 端到端集成测试
+
+使用 FastAPI TestClient + 内存 SQLite，测试完整的 HTTP 请求/响应链路：
+  - 认证：注册、登录、获取当前用户、更新用户信息
+  - 简历 CRUD：创建、列表、获取、更新、删除
+  - 聊天记录：追加、获取、清空
+  - 权限隔离：跨用户访问被拒绝
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.core.database import Base, get_db
+from app.main import app
+
+# ── 测试数据库 ──────────────────────────────────────────────────────────────
+
+TEST_DATABASE_URL = "sqlite://"  # 纯内存，每次测试都是空库
+
+_engine = create_engine(
+    TEST_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+
+def _override_get_db():
+    db = _TestingSession()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = _override_get_db
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session", autouse=True)
+def _create_tables():
+    """在整个测试会话开始时建表，结束时销毁。"""
+    Base.metadata.create_all(bind=_engine)
+    yield
+    Base.metadata.drop_all(bind=_engine)
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+# ── 辅助函数 ─────────────────────────────────────────────────────────────────
+
+def _register(client: TestClient, email: str, password: str = "password123", full_name: str | None = None):
+    payload = {"email": email, "password": password}
+    if full_name:
+        payload["full_name"] = full_name
+    return client.post("/api/auth/register", json=payload)
+
+
+def _login(client: TestClient, email: str, password: str = "password123") -> str:
+    resp = client.post(
+        "/api/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+def _auth_headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _empty_resume_content() -> dict:
+    return {
+        "job_application": {"target_company": "测试公司", "target_title": "后端工程师"},
+        "personal_info": {"name": "张三", "email": "zhangsan@example.com"},
+        "work_experience": [],
+        "education": [],
+        "skills": [],
+        "projects": [],
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. 认证流程
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestAuth:
+    def test_register_creates_user(self, client):
+        resp = _register(client, "new_user@example.com", full_name="新用户")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["email"] == "new_user@example.com"
+        assert body["full_name"] == "新用户"
+        assert "id" in body
+        assert "hashed_password" not in body
+
+    def test_register_duplicate_email_returns_400(self, client):
+        _register(client, "dup@example.com")
+        resp = _register(client, "dup@example.com")
+        assert resp.status_code == 400
+        assert "already registered" in resp.json()["detail"].lower()
+
+    def test_login_returns_token_and_user(self, client):
+        _register(client, "login_test@example.com", full_name="登录测试")
+        resp = client.post(
+            "/api/auth/login",
+            data={"username": "login_test@example.com", "password": "password123"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "access_token" in body
+        assert body["token_type"] == "bearer"
+        assert body["user"]["email"] == "login_test@example.com"
+
+    def test_login_wrong_password_returns_401(self, client):
+        _register(client, "wrong_pw@example.com")
+        resp = client.post(
+            "/api/auth/login",
+            data={"username": "wrong_pw@example.com", "password": "wrongpassword"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert resp.status_code == 401
+
+    def test_login_unknown_user_returns_401(self, client):
+        resp = client.post(
+            "/api/auth/login",
+            data={"username": "nobody@example.com", "password": "password123"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert resp.status_code == 401
+
+    def test_get_me_returns_current_user(self, client):
+        _register(client, "me_user@example.com", full_name="我")
+        token = _login(client, "me_user@example.com")
+        resp = client.get("/api/auth/me", headers=_auth_headers(token))
+        assert resp.status_code == 200
+        assert resp.json()["email"] == "me_user@example.com"
+
+    def test_get_me_without_token_returns_401(self, client):
+        resp = client.get("/api/auth/me")
+        assert resp.status_code == 401
+
+    def test_update_me_changes_full_name(self, client):
+        _register(client, "update_me@example.com", full_name="旧名字")
+        token = _login(client, "update_me@example.com")
+        resp = client.put(
+            "/api/auth/me",
+            json={"full_name": "新名字"},
+            headers=_auth_headers(token),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["full_name"] == "新名字"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. 简历 CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestResumeCRUD:
+    @pytest.fixture(autouse=True)
+    def _setup(self, client):
+        _register(client, "resume_user@example.com")
+        self.token = _login(client, "resume_user@example.com")
+        self.headers = _auth_headers(self.token)
+        self.client = client
+
+    def _create_resume(self, title: str = "我的简历") -> dict:
+        resp = self.client.post(
+            "/api/resumes/",
+            json={"title": title, "content": _empty_resume_content()},
+            headers=self.headers,
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    def test_create_resume_returns_resume(self):
+        body = self._create_resume("测试简历")
+        assert body["title"] == "测试简历"
+        assert "id" in body
+        assert body["content"]["personal_info"]["name"] == "张三"
+
+    def test_list_resumes_returns_created_items(self):
+        self._create_resume("简历A")
+        self._create_resume("简历B")
+        resp = self.client.get("/api/resumes/", headers=self.headers)
+        assert resp.status_code == 200
+        titles = [r["title"] for r in resp.json()]
+        assert "简历A" in titles
+        assert "简历B" in titles
+
+    def test_get_resume_by_id(self):
+        created = self._create_resume("可查简历")
+        resume_id = created["id"]
+        resp = self.client.get(f"/api/resumes/{resume_id}", headers=self.headers)
+        assert resp.status_code == 200
+        assert resp.json()["id"] == resume_id
+
+    def test_get_nonexistent_resume_returns_404(self):
+        resp = self.client.get("/api/resumes/9999999", headers=self.headers)
+        assert resp.status_code == 404
+
+    def test_update_resume_title(self):
+        created = self._create_resume("旧标题")
+        resume_id = created["id"]
+        resp = self.client.put(
+            f"/api/resumes/{resume_id}",
+            json={"title": "新标题"},
+            headers=self.headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "新标题"
+
+    def test_update_resume_content(self):
+        created = self._create_resume("内容更新测试")
+        resume_id = created["id"]
+        new_content = _empty_resume_content()
+        new_content["personal_info"]["name"] = "李四"
+        resp = self.client.put(
+            f"/api/resumes/{resume_id}",
+            json={"content": new_content},
+            headers=self.headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["content"]["personal_info"]["name"] == "李四"
+
+    def test_update_resume_with_no_data_returns_400(self):
+        created = self._create_resume("空更新测试")
+        resume_id = created["id"]
+        resp = self.client.put(
+            f"/api/resumes/{resume_id}",
+            json={},
+            headers=self.headers,
+        )
+        assert resp.status_code == 400
+
+    def test_delete_resume_removes_it(self):
+        created = self._create_resume("待删除简历")
+        resume_id = created["id"]
+        del_resp = self.client.delete(f"/api/resumes/{resume_id}", headers=self.headers)
+        assert del_resp.status_code == 200
+        get_resp = self.client.get(f"/api/resumes/{resume_id}", headers=self.headers)
+        assert get_resp.status_code == 404
+
+    def test_list_resumes_without_auth_returns_401(self):
+        resp = self.client.get("/api/resumes/")
+        assert resp.status_code == 401
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. 跨用户权限隔离
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestResumePermissions:
+    @pytest.fixture(autouse=True)
+    def _setup(self, client):
+        # 用户 A
+        _register(client, "user_a@example.com")
+        self.token_a = _login(client, "user_a@example.com")
+        # 用户 B
+        _register(client, "user_b@example.com")
+        self.token_b = _login(client, "user_b@example.com")
+        self.client = client
+
+        # 用户 A 创建一份简历
+        resp = client.post(
+            "/api/resumes/",
+            json={"title": "用户A的简历", "content": _empty_resume_content()},
+            headers=_auth_headers(self.token_a),
+        )
+        assert resp.status_code == 200
+        self.resume_id = resp.json()["id"]
+
+    def test_user_b_cannot_read_user_a_resume(self):
+        resp = self.client.get(
+            f"/api/resumes/{self.resume_id}",
+            headers=_auth_headers(self.token_b),
+        )
+        assert resp.status_code == 403
+
+    def test_user_b_cannot_update_user_a_resume(self):
+        resp = self.client.put(
+            f"/api/resumes/{self.resume_id}",
+            json={"title": "非法修改"},
+            headers=_auth_headers(self.token_b),
+        )
+        assert resp.status_code == 403
+
+    def test_user_b_cannot_delete_user_a_resume(self):
+        resp = self.client.delete(
+            f"/api/resumes/{self.resume_id}",
+            headers=_auth_headers(self.token_b),
+        )
+        assert resp.status_code == 403
+
+    def test_user_b_resume_list_does_not_include_user_a_resume(self):
+        resp = self.client.get(
+            "/api/resumes/",
+            headers=_auth_headers(self.token_b),
+        )
+        assert resp.status_code == 200
+        ids = [r["id"] for r in resp.json()]
+        assert self.resume_id not in ids
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. 聊天记录 CRUD
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestChatMessages:
+    @pytest.fixture(autouse=True)
+    def _setup(self, client):
+        _register(client, "chat_user@example.com")
+        self.token = _login(client, "chat_user@example.com")
+        self.headers = _auth_headers(self.token)
+        self.client = client
+
+        resp = client.post(
+            "/api/resumes/",
+            json={"title": "聊天简历", "content": _empty_resume_content()},
+            headers=self.headers,
+        )
+        assert resp.status_code == 200
+        self.resume_id = resp.json()["id"]
+
+    def test_append_and_get_messages(self):
+        msgs = [
+            {"role": "user", "content": "帮我优化简历"},
+            {"role": "assistant", "content": "好的，我来帮你优化"},
+        ]
+        post_resp = self.client.post(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            json=msgs,
+            headers=self.headers,
+        )
+        assert post_resp.status_code == 200
+        saved = post_resp.json()
+        assert len(saved) == 2
+        assert saved[0]["role"] == "user"
+        assert saved[1]["role"] == "assistant"
+
+        get_resp = self.client.get(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            headers=self.headers,
+        )
+        assert get_resp.status_code == 200
+        all_msgs = get_resp.json()
+        assert len(all_msgs) == 2
+
+    def test_messages_are_ordered_by_id(self):
+        for i in range(3):
+            self.client.post(
+                f"/api/resumes/{self.resume_id}/chat-messages",
+                json=[{"role": "user", "content": f"消息 {i}"}],
+                headers=self.headers,
+            )
+        get_resp = self.client.get(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            headers=self.headers,
+        )
+        msgs = get_resp.json()
+        ids = [m["id"] for m in msgs]
+        assert ids == sorted(ids)
+
+    def test_invalid_role_is_ignored(self):
+        resp = self.client.post(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            json=[{"role": "system", "content": "系统消息应被忽略"}],
+            headers=self.headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_clear_messages(self):
+        self.client.post(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            json=[{"role": "user", "content": "一条消息"}],
+            headers=self.headers,
+        )
+        del_resp = self.client.delete(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            headers=self.headers,
+        )
+        assert del_resp.status_code == 200
+
+        get_resp = self.client.get(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            headers=self.headers,
+        )
+        assert get_resp.json() == []
+
+    def test_append_messages_with_stream_events(self):
+        stream_events = [
+            {"type": "tool_confirmed", "diff": "添加了量化指标"},
+        ]
+        resp = self.client.post(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            json=[{"role": "assistant", "content": "已优化", "stream_events": stream_events}],
+            headers=self.headers,
+        )
+        assert resp.status_code == 200
+        saved = resp.json()
+        assert saved[0]["stream_events"] == stream_events
+
+    def test_chat_messages_forbidden_for_other_user(self):
+        _register(self.client, "other_chat@example.com")
+        other_token = _login(self.client, "other_chat@example.com")
+        resp = self.client.get(
+            f"/api/resumes/{self.resume_id}/chat-messages",
+            headers=_auth_headers(other_token),
+        )
+        assert resp.status_code == 403
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. 健康检查 & 根路由
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestHealthEndpoints:
+    def test_root_returns_200(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "Chat Resume" in resp.json()["message"]
+
+    def test_health_check_returns_healthy(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "healthy"

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * 认证流程端到端测试
+ *
+ * 覆盖：注册、登录、登出、表单校验
+ */
+
+import { test, expect } from '@playwright/test'
+import { uniqueEmail, DEFAULT_PASSWORD, registerUser } from './helpers'
+
+// ── 注册 ──────────────────────────────────────────────────────────────────
+
+test.describe('注册', () => {
+  test('新用户注册成功后跳转到 dashboard', async ({ page }) => {
+    const email = uniqueEmail('reg')
+    await registerUser(page, email)
+    await page.waitForURL('**/dashboard', { timeout: 12_000 })
+    await expect(page).toHaveURL(/\/dashboard/)
+  })
+
+  test('重复邮箱注册显示错误提示', async ({ page }) => {
+    const email = uniqueEmail('dup')
+    // 第一次成功注册
+    await registerUser(page, email)
+    await page.waitForURL('**/dashboard', { timeout: 12_000 })
+
+    // 退出：清 storage 模拟登出
+    await page.evaluate(() => localStorage.clear())
+
+    // 再次注册同一邮箱
+    await registerUser(page, email)
+
+    // 应停留在注册页（不跳转到 dashboard）
+    await page.waitForTimeout(2000)
+    expect(page.url()).not.toMatch(/\/dashboard/)
+  })
+
+  test('两次密码不一致时表单提交被阻止', async ({ page }) => {
+    await page.goto('/register')
+    await page.fill('input[placeholder="请输入您的姓名"]', '不一致')
+    await page.fill('input[type="email"]', uniqueEmail('mismatch'))
+    const pwInputs = page.locator('input[type="password"]')
+    await pwInputs.nth(0).fill(DEFAULT_PASSWORD)
+    await pwInputs.nth(1).fill('WrongConfirm123')
+    const checkbox = page.locator('input[type="checkbox"]').first()
+    if (await checkbox.count() > 0) await checkbox.check()
+    await page.click('button[type="submit"]')
+
+    await page.waitForTimeout(1000)
+    expect(page.url()).not.toMatch(/\/dashboard/)
+  })
+
+  test('页面包含跳转到登录页的链接', async ({ page }) => {
+    await page.goto('/register')
+    const loginLink = page.locator('a[href="/login"]')
+    await expect(loginLink).toBeVisible()
+  })
+})
+
+// ── 登录 ──────────────────────────────────────────────────────────────────
+
+test.describe('登录', () => {
+  let testEmail: string
+
+  test.beforeAll(async ({ browser }) => {
+    testEmail = uniqueEmail('login')
+    const page = await browser.newPage()
+    await registerUser(page, testEmail)
+    await page.waitForURL('**/dashboard', { timeout: 12_000 })
+    await page.close()
+  })
+
+  test('正确凭据登录后跳转到 dashboard', async ({ page }) => {
+    await page.goto('/login')
+    await page.fill('input[type="email"]', testEmail)
+    await page.fill('input[type="password"]', DEFAULT_PASSWORD)
+    await page.click('button[type="submit"]')
+    await page.waitForURL('**/dashboard', { timeout: 12_000 })
+    await expect(page).toHaveURL(/\/dashboard/)
+  })
+
+  test('错误密码停留在登录页', async ({ page }) => {
+    await page.goto('/login')
+    await page.fill('input[type="email"]', testEmail)
+    await page.fill('input[type="password"]', 'WrongPassword999')
+    await page.click('button[type="submit"]')
+    await page.waitForTimeout(2000)
+    expect(page.url()).not.toMatch(/\/dashboard/)
+  })
+
+  test('未填写邮箱不允许提交', async ({ page }) => {
+    await page.goto('/login')
+    await page.fill('input[type="password"]', DEFAULT_PASSWORD)
+    await page.click('button[type="submit"]')
+    await page.waitForTimeout(500)
+    expect(page.url()).not.toMatch(/\/dashboard/)
+  })
+
+  test('未登录访问 dashboard 会跳转到 login 或 register', async ({ page }) => {
+    await page.context().clearCookies()
+    // 先导航到一个普通页面才能访问 localStorage
+    await page.goto('/login')
+    await page.evaluate(() => localStorage.clear())
+    await page.goto('/dashboard')
+    await page.waitForURL(/\/(login|register)/, { timeout: 10_000 })
+    expect(page.url()).toMatch(/\/(login|register)/)
+  })
+
+  test('页面包含跳转到注册页的链接', async ({ page }) => {
+    await page.goto('/login')
+    const regLink = page.locator('a[href="/register"]')
+    await expect(regLink).toBeVisible()
+  })
+})

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Dashboard 端到端测试
+ *
+ * 覆盖：新建简历、简历列表展示、删除简历
+ */
+
+import { test, expect, Page } from '@playwright/test'
+import { uniqueEmail, DEFAULT_PASSWORD, registerUser } from './helpers'
+
+/** 注册并等待跳转到 dashboard */
+async function loginAs(page: Page, email: string) {
+  await registerUser(page, email)
+  await page.waitForURL('**/dashboard', { timeout: 12_000 })
+}
+
+// ── Dashboard 基础 ──────────────────────────────────────────────────────────
+
+test.describe('Dashboard', () => {
+  test('登录后显示仪表板页面', async ({ page }) => {
+    await loginAs(page, uniqueEmail('dash'))
+    await expect(page.locator('h1')).toContainText(/简历中心|仪表板|Dashboard/i)
+  })
+
+  test('没有简历时显示空状态提示', async ({ page }) => {
+    await loginAs(page, uniqueEmail('empty'))
+    await page.waitForSelector('.animate-spin', { state: 'detached', timeout: 8_000 }).catch(() => {})
+    await expect(page.locator('body')).toContainText(/还没有简历|上传|新建/i)
+  })
+
+  test('页面包含上传简历和新建简历按钮', async ({ page }) => {
+    await loginAs(page, uniqueEmail('btn'))
+    await expect(page.getByText(/上传简历/).first()).toBeVisible()
+    await expect(page.getByText(/新建简历/)).toBeVisible()
+  })
+})
+
+// ── 新建简历 ─────────────────────────────────────────────────────────────────
+
+test.describe('新建简历', () => {
+  test('点击新建简历弹出标题输入框', async ({ page }) => {
+    await loginAs(page, uniqueEmail('create'))
+    await page.getByText('新建简历').click()
+    await expect(page.locator('input#resumeTitle')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('输入标题后点击创建跳转到编辑页或 dashboard', async ({ page }) => {
+    await loginAs(page, uniqueEmail('createok'))
+    await page.getByText('新建简历').click()
+
+    const titleInput = page.locator('input#resumeTitle').first()
+    await titleInput.waitFor({ state: 'visible', timeout: 5_000 })
+    await titleInput.fill('端到端测试简历')
+
+    await page.getByRole('button', { name: /创建简历/ }).click()
+    await page.waitForURL(/\/(dashboard|resume)/, { timeout: 12_000 })
+  })
+
+  test('标题为空时创建按钮处于禁用状态', async ({ page }) => {
+    await loginAs(page, uniqueEmail('emptytitle'))
+    await page.getByText('新建简历').click()
+
+    const confirmBtn = page.getByRole('button', { name: /创建简历/ })
+    await confirmBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    await expect(confirmBtn).toBeDisabled()
+  })
+
+  test('点击取消关闭弹窗', async ({ page }) => {
+    await loginAs(page, uniqueEmail('cancel'))
+    await page.getByText('新建简历').click()
+
+    const cancelBtn = page.getByRole('button', { name: /取消/ })
+    await cancelBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    await cancelBtn.click()
+
+    await expect(page.locator('input#resumeTitle')).not.toBeVisible({ timeout: 3_000 })
+  })
+})
+
+// ── 简历列表操作 ──────────────────────────────────────────────────────────────
+
+test.describe('简历列表', () => {
+  test('创建简历后编辑页展示该简历标题，返回 dashboard 列表中也出现', async ({ page }) => {
+    await loginAs(page, uniqueEmail('listtest'))
+
+    await page.getByText('新建简历').click()
+    const titleInput = page.locator('input#resumeTitle').first()
+    await titleInput.waitFor({ state: 'visible', timeout: 5_000 })
+    await titleInput.fill('我的前端简历')
+    await page.getByRole('button', { name: /创建简历/ }).click()
+
+    // 创建成功后跳转到编辑页
+    await page.waitForURL(/\/resume\/\d+/, { timeout: 12_000 })
+    // 编辑页的简历名称输入框 value 应该是 "我的前端简历"
+    const resumeTitleInput = page.locator('input[value="我的前端简历"], input').filter({ hasValue: '我的前端简历' })
+    await expect(resumeTitleInput.first()).toBeVisible({ timeout: 5_000 })
+
+    // 回到 dashboard，等待列表加载
+    await page.goto('/dashboard')
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {})
+    await expect(page.locator('body')).toContainText('我的前端简历', { timeout: 8_000 })
+  })
+
+  test('简历卡片包含 Chat 按钮', async ({ page }) => {
+    await loginAs(page, uniqueEmail('chatbtn'))
+
+    await page.getByText('新建简历').click()
+    const titleInput = page.locator('input#resumeTitle').first()
+    await titleInput.waitFor({ state: 'visible', timeout: 5_000 })
+    await titleInput.fill('Chat 按钮测试')
+    await page.getByRole('button', { name: /创建简历/ }).click()
+
+    await page.waitForURL(/\/(dashboard|resume)/, { timeout: 12_000 })
+    if (!page.url().includes('/dashboard')) {
+      await page.goto('/dashboard')
+    }
+
+    await page.waitForSelector('.animate-spin', { state: 'detached', timeout: 8_000 }).catch(() => {})
+    await expect(page.getByText('Chat').first()).toBeVisible()
+  })
+})

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * 测试辅助工具
+ *
+ * 封装测试中常用的注册/登录/初始化操作，避免每个 spec 文件重复写相同逻辑。
+ */
+
+import { Page } from '@playwright/test'
+
+/** 生成不重复的测试邮箱（基于时间戳 + 随机数） */
+export function uniqueEmail(prefix = 'e2e'): string {
+  return `${prefix}_${Date.now()}_${Math.floor(Math.random() * 9999)}@test.example`
+}
+
+export const DEFAULT_PASSWORD = 'Test@12345'
+
+/**
+ * 通过 UI 注册新用户。
+ * 填写：姓名、邮箱、密码×2、服务条款复选框，然后提交。
+ * 注意：不在此函数内等待跳转，由调用方负责。
+ */
+export async function registerUser(page: Page, email: string, password = DEFAULT_PASSWORD) {
+  await page.goto('/register')
+  await page.fill('input[placeholder="请输入您的姓名"]', '测试用户')
+  await page.fill('input[type="email"]', email)
+  const pwInputs = page.locator('input[type="password"]')
+  await pwInputs.nth(0).fill(password)
+  await pwInputs.nth(1).fill(password)
+  // 勾选服务条款复选框
+  const checkbox = page.locator('input[type="checkbox"]').first()
+  if (await checkbox.count() > 0) {
+    await checkbox.check()
+  }
+  await page.click('button[type="submit"]')
+}
+
+/** 通过 UI 登录，等待跳转到 dashboard */
+export async function loginUser(page: Page, email: string, password = DEFAULT_PASSWORD) {
+  await page.goto('/login')
+  await page.fill('input[type="email"]', email)
+  await page.fill('input[type="password"]', password)
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/dashboard', { timeout: 10_000 })
+}
+
+/** 注册 → 等待跳转 → 返回 email */
+export async function registerAndLogin(page: Page, prefix = 'e2e'): Promise<string> {
+  const email = uniqueEmail(prefix)
+  await registerUser(page, email)
+  await page.waitForURL('**/dashboard', { timeout: 10_000 })
+  return email
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "zustand": "^4.4.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/node": "^20.10.5",
         "@types/react": "^18.2.45",
         "@types/react-dom": "^18.2.18",
@@ -519,6 +520,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -5747,6 +5764,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
@@ -33,6 +35,7 @@
     "zustand": "^4.4.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^20.10.5",
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: 'list',
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    // 等待网络请求时超时
+    actionTimeout: 10_000,
+    navigationTimeout: 15_000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})


### PR DESCRIPTION
## Summary

- 新增后端 API 集成测试（`backend/tests/test_api_e2e.py`，29 个测试），使用 FastAPI TestClient + 内存 SQLite，零外部依赖
- 新增前端 Playwright E2E 测试（`frontend/e2e/`，18 个测试），覆盖注册/登录/仪表板/简历创建完整用户旅程
- 引入 `@playwright/test` 并配置 `playwright.config.ts`

## 覆盖范围

**后端（29 个）**
- 认证：注册、重复邮箱 400、登录、错误密码 401、获取 /me、更新 /me
- 简历 CRUD：创建、列表、按 ID 获取、更新标题/内容、删除、404/400/401 边界
- 跨用户权限隔离：403 场景、列表隔离
- 聊天记录：追加、获取、排序、非法 role 忽略、清空、跨用户 403
- 健康检查

**前端（18 个）**
- 注册：成功跳转、重复邮箱错误、密码不一致阻止、跳转链接
- 登录：成功跳转、错误密码、空字段、未登录重定向保护
- 仪表板：展示、空状态、按钮可见、新建弹窗、创建跳转、禁用状态、取消弹窗、列表验证、Chat 按钮

## Test plan

- [ ] `cd backend && uv run pytest tests/test_api_e2e.py -v` → 29 passed
- [ ] 启动前后端后：`cd frontend && npm run e2e` → 18 passed