### PR TITLE
[codex] Refine resume editor UI

### DIFF
--- a/frontend/src/app/resume/[id]/edit/page.tsx
+++ b/frontend/src/app/resume/[id]/edit/page.tsx
@@ -979,8 +979,8 @@ export default function ResumeEditPage() {
                   title="自动调整间距使简历恰好一页"
                   className={`inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg border transition-colors
                     ${isSmartFitting
-                      ? 'border-blue-300 bg-blue-50 text-blue-500 cursor-wait'
-                      : 'border-blue-500 bg-blue-50 text-blue-600 hover:bg-blue-100'
+                      ? 'border-gray-300 bg-white text-gray-500 cursor-wait'
+                      : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
                     }`}
                 >
                   {isSmartFitting ? (
@@ -1235,7 +1235,7 @@ export default function ResumeEditPage() {
                     >
                       <div
                         className={`max-w-[85%] px-4 py-3 rounded-2xl ${message.type === 'user'
-                          ? 'bg-primary-600 text-white rounded-br-md text-sm shadow-sm'
+                          ? 'bg-primary-600 text-white rounded-br-md text-[14px] shadow-sm'
                           : 'bg-gray-50 text-gray-800 rounded-bl-md border border-gray-100 shadow-xs'
                           }`}
                       >
@@ -1285,7 +1285,7 @@ export default function ResumeEditPage() {
                             {renderProposalCard(message)}
                           </>
                         ) : (
-                          <span className="text-sm">{message.content}</span>
+                          <span className="text-[14px]">{message.content}</span>
                         )}
                       </div>
                     </div>
@@ -1386,7 +1386,7 @@ export default function ResumeEditPage() {
                           )
                         })}
                         {!streamEvents.some((event) => event.type === 'text' && event.content.trim()) && (
-                          <div className="mt-2 rounded-2xl rounded-bl-md border border-gray-200 bg-white px-4 py-3 text-sm text-gray-500 shadow-sm">
+                          <div className="mt-2 rounded-2xl rounded-bl-md border border-gray-200 bg-white px-4 py-3 text-[14px] text-gray-500 shadow-sm">
                             <span className="inline-block animate-pulse">Planning next moves</span>
                           </div>
                         )}
@@ -1397,7 +1397,7 @@ export default function ResumeEditPage() {
                   {/* 等待响应动画 */}
                   {(isSending || isStreaming) && streamEvents.length === 0 && (
                     <div className="flex w-full justify-start">
-                      <div className="max-w-[85%] rounded-2xl rounded-bl-md border border-gray-200 bg-white px-4 py-3 text-sm text-gray-500 shadow-sm">
+                      <div className="max-w-[85%] rounded-2xl rounded-bl-md border border-gray-200 bg-white px-4 py-3 text-[14px] text-gray-500 shadow-sm">
                         <span className="inline-block animate-pulse">Planning next moves</span>
                       </div>
                     </div>

--- a/frontend/src/app/resume/[id]/interview/page.tsx
+++ b/frontend/src/app/resume/[id]/interview/page.tsx
@@ -218,14 +218,14 @@ export default function InterviewPage() {
                       <div
                         className={`max-w-[85%] px-4 py-3 rounded-2xl ${
                           message.type === 'user'
-                            ? 'bg-primary-600 text-white rounded-br-md text-sm shadow-sm'
+                            ? 'bg-primary-600 text-white rounded-br-md text-[14px] shadow-sm'
                             : 'bg-gray-50 text-gray-800 rounded-bl-md border border-gray-100 shadow-xs'
                         }`}
                       >
                         {message.type === 'ai' ? (
                           <MarkdownMessage content={message.content} />
                         ) : (
-                          <span className="text-sm">{message.content}</span>
+                          <span className="text-[14px]">{message.content}</span>
                         )}
                       </div>
                     </div>
@@ -243,7 +243,7 @@ export default function InterviewPage() {
                   {/* Thinking */}
                   {(isSending || isStreaming) && !currentStreamingMessage && (
                     <div className="flex w-full justify-start">
-                      <div className="max-w-[85%] rounded-2xl rounded-bl-md border border-gray-200 bg-white px-4 py-3 text-sm text-gray-500 shadow-sm">
+                      <div className="max-w-[85%] rounded-2xl rounded-bl-md border border-gray-200 bg-white px-4 py-3 text-[14px] text-gray-500 shadow-sm">
                         <span className="inline-block animate-pulse">思考中...</span>
                       </div>
                     </div>

--- a/frontend/src/components/editor/ProjectsEditor.tsx
+++ b/frontend/src/components/editor/ProjectsEditor.tsx
@@ -270,9 +270,6 @@ export default function ProjectsEditor({ data, onChange }: ProjectsEditorProps) 
                       </div>
                     ))}
                   </div>
-                  <p className="text-xs text-gray-500 mt-1">
-                    💡 建议包含具体数据和指标，突出个人贡献和技术难点
-                  </p>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/editor/SkillsEditor.tsx
+++ b/frontend/src/components/editor/SkillsEditor.tsx
@@ -151,7 +151,7 @@ export default function SkillsEditor({ data, onChange }: SkillsEditorProps) {
               return (
                 <span
                   key={key}
-                  className="group/chip relative inline-flex items-center justify-center rounded-full border border-gray-200 hover:border-gray-300 transition-colors px-3 py-1"
+                  className="group/chip relative inline-flex items-center justify-center rounded-full border border-gray-200 hover:border-gray-300 transition-colors px-2.5 py-1"
                 >
                   <input
                     ref={(el) => { chipRefs.current.set(key, el) }}
@@ -168,7 +168,7 @@ export default function SkillsEditor({ data, onChange }: SkillsEditorProps) {
                       }
                     }}
                     placeholder="技能"
-                    className="bg-transparent border-0 focus:ring-0 focus:outline-none text-sm text-gray-800 p-0 text-center"
+                    className="bg-transparent border-0 focus:ring-0 focus:outline-none text-xs text-gray-800 p-0 text-center"
                     style={{ width: `${Math.max(item.length, 2) + 1}ch` }}
                   />
                   <button

--- a/frontend/src/components/preview/PaginatedResumePreview.tsx
+++ b/frontend/src/components/preview/PaginatedResumePreview.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useLineBasedPagination, A4_WIDTH, PAGE_PADDING } from './hooks/useLineBasedPagination'
+import { useLineBasedPagination, measureRenderableLines, A4_WIDTH, PAGE_PADDING } from './hooks/useLineBasedPagination'
 import { useSmartFit } from './hooks/useSmartFit'
 import ResumePage from './ResumePage'
 import PersonalInfoPreview from './sections/PersonalInfoPreview'
@@ -119,6 +119,7 @@ export default function PaginatedResumePreview({
 }: PaginatedResumePreviewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
+  const smartFitContentRef = useRef<HTMLDivElement>(null)
   const [scale, setScale] = React.useState(1)
 
   // 独立的测量容器 scale state，仅供 SmartFit 二分搜索时切换，不影响实际渲染
@@ -154,7 +155,7 @@ export default function PaginatedResumePreview({
       .sort((a, b) => a.order - b.order)
   }, [moduleOrderKey])
 
-  const { pages, totalPages, isCalculating, measureLines } = useLineBasedPagination({
+  const { pages, totalPages, isCalculating } = useLineBasedPagination({
     containerRef,
     contentRef,
     spacingScale
@@ -164,12 +165,16 @@ export default function PaginatedResumePreview({
     onSpacingScaleChange?.(newScale)
   }, [onSpacingScaleChange])
 
+  const measureSmartFitLines = useCallback(() => {
+    return measureRenderableLines(smartFitContentRef.current)
+  }, [])
+
   const { runSmartFit } = useSmartFit({
     currentScale: spacingScale,
     onComplete: handleSmartFitComplete,
     setMeasureScale,
     waitForMeasureScale,
-    measureLines,
+    measureLines: measureSmartFitLines,
   })
 
   // 将 runSmartFit 暴露给父组件
@@ -256,10 +261,36 @@ export default function PaginatedResumePreview({
     }
   }
 
-  // 渲染所有内容用于测量
-  const measurementContent = useMemo(() => (
+  // 渲染所有内容用于正式分页测量
+  const paginationMeasurementContent = useMemo(() => (
     <div
       ref={contentRef}
+      className="invisible absolute -top-[9999px] left-0 pointer-events-none"
+      style={{
+        width: `${A4_WIDTH}px`,
+        paddingTop: `${PAGE_PADDING * spacingScale}px`,
+        paddingBottom: `${PAGE_PADDING * spacingScale}px`,
+        paddingLeft: `${PAGE_PADDING}px`,
+        paddingRight: `${PAGE_PADDING}px`,
+        boxSizing: 'border-box',
+        ['--spacing-scale' as string]: String(spacingScale)
+      }}
+    >
+      {visibleModules.map((module) => {
+        const sectionElement = renderModule(module.type)
+        if (!sectionElement) {
+          return null
+        }
+        return React.cloneElement(sectionElement, { key: module.type })
+      })}
+    </div>
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), [content, visibleModules, moduleOrderKey, spacingScale])
+
+  // 智能一页试算专用测量容器；二分搜索时会频繁切换 scale，不参与正式分页。
+  const smartFitMeasurementContent = useMemo(() => (
+    <div
+      ref={smartFitContentRef}
       className="invisible absolute -top-[9999px] left-0 pointer-events-none"
       style={{
         width: `${A4_WIDTH}px`,
@@ -350,7 +381,8 @@ export default function PaginatedResumePreview({
   return (
     <div id="resume-preview-content" ref={containerRef} className="w-full h-full flex flex-col items-center">
       {/* 用于测量的隐藏内容 */}
-      {measurementContent}
+      {paginationMeasurementContent}
+      {smartFitMeasurementContent}
 
       {/* 加载状态 */}
       {isCalculating && (

--- a/frontend/src/components/preview/ResumeLayoutControls.tsx
+++ b/frontend/src/components/preview/ResumeLayoutControls.tsx
@@ -2,10 +2,7 @@
 
 import { useState } from 'react'
 import { 
-  AdjustmentsHorizontalIcon,
-  Bars3BottomLeftIcon,
-  EyeIcon,
-  EyeSlashIcon
+  AdjustmentsHorizontalIcon
 } from '@heroicons/react/24/outline'
 import {
   LayoutDensity,
@@ -27,7 +24,7 @@ export default function ResumeLayoutControls({
   className = ''
 }: ResumeLayoutControlsProps) {
   const [showControls, setShowControls] = useState(false)
-  const [activeTab, setActiveTab] = useState<'density' | 'modules' | 'order'>('density')
+  const [activeTab, setActiveTab] = useState<'density' | 'modules'>('density')
 
   const handleDensityChange = (density: LayoutDensity) => {
     const spacingScale = DENSITY_SPACING_SCALE[density as Exclude<LayoutDensity, 'custom'>] ?? config.spacingScale
@@ -136,28 +133,15 @@ export default function ResumeLayoutControls({
               >
                 显示
               </button>
-              <button
-                onClick={() => setActiveTab('order')}
-                className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${
-                  activeTab === 'order'
-                    ? 'text-blue-600 border-b-2 border-blue-600'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                顺序
-              </button>
             </div>
 
             {/* 内容区域 */}
-            <div className="p-4 max-h-96 overflow-y-auto">
+            <div className="p-4">
               {/* 密度选项 */}
               {activeTab === 'density' && (
                 <div className="space-y-4">
                   {/* 第一层：快速预设 */}
                   <div>
-                    <p className="text-xs text-gray-500 mb-3">
-                      调整简历的信息密度，紧凑模式可在一页纸放入更多内容
-                    </p>
                     <div className="space-y-2">
                       {(['comfortable', 'normal', 'compact'] as Exclude<LayoutDensity, 'custom'>[]).map((density) => (
                         <label
@@ -178,11 +162,6 @@ export default function ResumeLayoutControls({
                               {density === 'comfortable' && '舒适'}
                               {density === 'normal' && '标准'}
                               {density === 'compact' && '紧凑'}
-                            </div>
-                            <div className="text-xs text-gray-500 mt-0.5">
-                              {density === 'comfortable' && '宽松间距，适合内容较少的简历'}
-                              {density === 'normal' && '平衡的间距，推荐使用'}
-                              {density === 'compact' && '紧凑间距，适合内容丰富的简历'}
                             </div>
                           </div>
                         </label>
@@ -224,13 +203,10 @@ export default function ResumeLayoutControls({
               {/* 模块显示控制 */}
               {activeTab === 'modules' && (
                 <div className="space-y-2">
-                  <p className="text-xs text-gray-500 mb-4">
-                    控制哪些模块在简历中显示
-                  </p>
-                  {config.moduleOrder.map((module) => (
-                    <label
+                  {config.moduleOrder.map((module, index) => (
+                    <div
                       key={module}
-                      className="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-gray-50 transition-colors"
+                      className="flex items-center gap-3 p-3 border rounded-lg bg-white hover:bg-gray-50 transition-colors"
                     >
                       <input
                         type="checkbox"
@@ -238,33 +214,6 @@ export default function ResumeLayoutControls({
                         onChange={() => toggleModuleVisibility(module)}
                         className="rounded"
                       />
-                      <div className="flex-1">
-                        <div className="font-medium text-sm flex items-center gap-2">
-                          {config.visibleModules.has(module) ? (
-                            <EyeIcon className="w-4 h-4 text-green-600" />
-                          ) : (
-                            <EyeSlashIcon className="w-4 h-4 text-gray-400" />
-                          )}
-                          {MODULE_LABELS[module]}
-                        </div>
-                      </div>
-                    </label>
-                  ))}
-                </div>
-              )}
-
-              {/* 模块顺序控制 */}
-              {activeTab === 'order' && (
-                <div className="space-y-2">
-                  <p className="text-xs text-gray-500 mb-4">
-                    拖动或使用按钮调整模块显示顺序
-                  </p>
-                  {config.moduleOrder.map((module, index) => (
-                    <div
-                      key={module}
-                      className="flex items-center gap-2 p-3 border rounded-lg bg-white"
-                    >
-                      <Bars3BottomLeftIcon className="w-5 h-5 text-gray-400" />
                       <div className="flex-1 font-medium text-sm">
                         {MODULE_LABELS[module]}
                       </div>
@@ -295,17 +244,9 @@ export default function ResumeLayoutControls({
                 </div>
               )}
             </div>
-
-            {/* 底部提示 */}
-            <div className="p-3 bg-gray-50 border-t border-gray-200 rounded-b-lg">
-              <p className="text-xs text-gray-500">
-                💡 提示：设置会自动保存到浏览器
-              </p>
-            </div>
           </div>
         </>
       )}
     </div>
   )
 }
-

--- a/frontend/src/components/preview/hooks/useLineBasedPagination.ts
+++ b/frontend/src/components/preview/hooks/useLineBasedPagination.ts
@@ -22,6 +22,68 @@ export interface PageContent {
   height: number
 }
 
+export function measureRenderableLines(contentElement: HTMLElement | null): RenderableLine[] {
+  if (!contentElement) return []
+
+  const lines: RenderableLine[] = []
+  const sections = contentElement.children
+
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i] as HTMLElement
+    const sectionId = section.getAttribute('data-section-id') || `section-${i}`
+
+    // 计算 section 级别的额外间距（section wrapper + inner div 的 margin-bottom）
+    // 这部分加在该 section 最后一行上，让分页器感知到 section 之间的真实间隔
+    const sectionStyle = window.getComputedStyle(section)
+    const sectionMarginBottom = parseFloat(sectionStyle.marginBottom) || 0
+
+    // inner div 的 marginBottom（section 组件自身的外层 div）
+    const firstChild = section.firstElementChild as HTMLElement | null
+    const innerDivMarginBottom = firstChild
+      ? (parseFloat(window.getComputedStyle(firstChild).marginBottom) || 0)
+      : 0
+
+    // 获取 section 下的所有可分页行元素
+    const lineElements = section.querySelectorAll('[data-line-index]')
+    const sectionLines: RenderableLine[] = []
+
+    for (let j = 0; j < lineElements.length; j++) {
+      const lineElement = lineElements[j] as HTMLElement
+      const lineIndex = parseInt(lineElement.getAttribute('data-line-index') || '0')
+
+      if (lineElement.offsetHeight > 0) {
+        // 将该行自身的 marginBottom 纳入高度，避免低估行间距
+        const elMarginBottom = parseFloat(window.getComputedStyle(lineElement).marginBottom) || 0
+        sectionLines.push({
+          id: `${sectionId}-line-${lineIndex}`,
+          sectionType: sectionId,
+          lineIndex,
+          height: lineElement.offsetHeight + elMarginBottom,
+          element: lineElement
+        })
+      }
+    }
+
+    // 将 section 级别的额外间距加到该 section 最后一行上
+    // CSS margin collapse: 最后一行的 marginBottom、innerDiv 的 marginBottom、section 的 marginBottom
+    // 三者之间发生折叠，实际间距为三者的最大值，而非相加
+    if (sectionLines.length > 0) {
+      const lastLine = sectionLines[sectionLines.length - 1]
+      const lastLineEl = lastLine.element
+      const lastLineElMarginBottom = parseFloat(window.getComputedStyle(lastLineEl).marginBottom) || 0
+      // 折叠后的实际间距
+      const collapsedGap = Math.max(lastLineElMarginBottom, innerDivMarginBottom, sectionMarginBottom)
+      // 已在循环中计入了 lastLineElMarginBottom，这里只补充差额
+      const additionalOverhead = collapsedGap - lastLineElMarginBottom
+      lastLine.height += additionalOverhead
+    }
+
+    lines.push(...sectionLines)
+  }
+
+  return lines
+}
+
 interface LineBasedPaginationOptions {
   containerRef: React.RefObject<HTMLElement>
   contentRef: React.RefObject<HTMLElement>
@@ -45,67 +107,7 @@ export function useLineBasedPagination({
   // 测量所有可分页的行元素
   // 注意：offsetHeight 不含 margin，需手动加上 marginBottom 避免分页高度低估导致内容被 overflow-hidden 裁掉
   const measureLines = useCallback((): RenderableLine[] => {
-    if (!contentRef.current) return []
-
-    const lines: RenderableLine[] = []
-    const sections = contentRef.current.children
-
-    for (let i = 0; i < sections.length; i++) {
-      const section = sections[i] as HTMLElement
-      const sectionId = section.getAttribute('data-section-id') || `section-${i}`
-
-      // 计算 section 级别的额外间距（section wrapper + inner div 的 margin-bottom）
-      // 这部分加在该 section 最后一行上，让分页器感知到 section 之间的真实间隔
-      const sectionStyle = window.getComputedStyle(section)
-      const sectionMarginBottom = parseFloat(sectionStyle.marginBottom) || 0
-
-      // inner div 的 marginBottom（section 组件自身的外层 div）
-      const firstChild = section.firstElementChild as HTMLElement | null
-      const innerDivMarginBottom = firstChild
-        ? (parseFloat(window.getComputedStyle(firstChild).marginBottom) || 0)
-        : 0
-
-      const sectionOverhead = sectionMarginBottom + innerDivMarginBottom
-
-      // 获取 section 下的所有可分页行元素
-      const lineElements = section.querySelectorAll('[data-line-index]')
-      const sectionLines: RenderableLine[] = []
-
-      for (let j = 0; j < lineElements.length; j++) {
-        const lineElement = lineElements[j] as HTMLElement
-        const lineIndex = parseInt(lineElement.getAttribute('data-line-index') || '0')
-
-        if (lineElement.offsetHeight > 0) {
-          // 将该行自身的 marginBottom 纳入高度，避免低估行间距
-          const elMarginBottom = parseFloat(window.getComputedStyle(lineElement).marginBottom) || 0
-          sectionLines.push({
-            id: `${sectionId}-line-${lineIndex}`,
-            sectionType: sectionId,
-            lineIndex,
-            height: lineElement.offsetHeight + elMarginBottom,
-            element: lineElement
-          })
-        }
-      }
-
-      // 将 section 级别的额外间距加到该 section 最后一行上
-      // CSS margin collapse: 最后一行的 marginBottom、innerDiv 的 marginBottom、section 的 marginBottom
-      // 三者之间发生折叠，实际间距为三者的最大值，而非相加
-      if (sectionLines.length > 0) {
-        const lastLine = sectionLines[sectionLines.length - 1]
-        const lastLineEl = lastLine.element
-        const lastLineElMarginBottom = parseFloat(window.getComputedStyle(lastLineEl).marginBottom) || 0
-        // 折叠后的实际间距
-        const collapsedGap = Math.max(lastLineElMarginBottom, innerDivMarginBottom, sectionMarginBottom)
-        // 已在循环中计入了 lastLineElMarginBottom，这里只补充差额
-        const additionalOverhead = collapsedGap - lastLineElMarginBottom
-        lastLine.height += additionalOverhead
-      }
-
-      lines.push(...sectionLines)
-    }
-
-    return lines
+    return measureRenderableLines(contentRef.current)
   }, [contentRef])
 
   // 贪心分页算法：按行填充页面
@@ -227,4 +229,3 @@ export function useLineBasedPagination({
     PAGE_PADDING
   }
 }
-

--- a/frontend/src/components/preview/hooks/useSmartFit.ts
+++ b/frontend/src/components/preview/hooks/useSmartFit.ts
@@ -40,9 +40,11 @@ export function useSmartFit({
 
     setIsRunning(true)
     abortRef.current = false
+    let finalMeasureScale = currentScale
 
     // 通过 React state 切换测量容器到指定 scale，等待渲染完成后测量
     const measureTotalHeight = async (scale: number): Promise<number> => {
+      finalMeasureScale = scale
       setMeasureScale(scale)
       await waitForMeasureScale(scale)
       const lines = measureLines()
@@ -99,10 +101,11 @@ export function useSmartFit({
       }
 
       onComplete(bestScale)
+      finalMeasureScale = bestScale
       return { status: 'success', oldScale: currentScale, newScale: bestScale }
     } finally {
-      // 恢复测量容器到当前实际 scale（会在 onComplete 触发 prop 变化后自动同步）
-      setMeasureScale(currentScale)
+      // 保持试算容器停在最后一次已渲染的 scale，避免 finally 再触发一次过期 scale 测量。
+      setMeasureScale(finalMeasureScale)
       setIsRunning(false)
     }
   }, [currentScale, isRunning, onComplete, setMeasureScale, waitForMeasureScale, measureLines])

--- a/frontend/src/components/preview/sections/EducationPreview.tsx
+++ b/frontend/src/components/preview/sections/EducationPreview.tsx
@@ -26,7 +26,7 @@ export function EducationItem({ edu, lineIndex }: { edu: Education; lineIndex: n
 
   return (
     <div data-line-index={lineIndex} className="relative print:break-inside-avoid" style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 12px)' }}>
-      <div className="flex justify-between items-start mb-1">
+      <div className="flex justify-between items-start" style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 4px)' }}>
         <div className="flex-1 flex flex-wrap items-center gap-2">
           <h3 className="font-semibold text-gray-900">
             {edu.school}
@@ -44,9 +44,15 @@ export function EducationItem({ edu, lineIndex }: { edu: Education; lineIndex: n
       </div>
 
       {highlights.length > 0 && (
-        <ul className="list-disc list-inside text-sm text-gray-600 mt-1">
+        <ul
+          className="list-disc list-inside text-sm text-gray-600"
+          style={{
+            marginTop: 'calc(var(--spacing-scale, 1) * 4px)',
+            lineHeight: 'calc(1.35 + var(--spacing-scale, 1) * 0.25)'
+          }}
+        >
           {highlights.map((item, index) => (
-            <li key={index}>{item}</li>
+            <li key={index} style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 2px)' }}>{item}</li>
           ))}
         </ul>
       )}

--- a/frontend/src/components/preview/sections/ProjectsPreview.tsx
+++ b/frontend/src/components/preview/sections/ProjectsPreview.tsx
@@ -56,7 +56,7 @@ export function ProjectItem({ project, lineIndex }: { project: Project; lineInde
 
   return (
     <div data-line-index={lineIndex} className="relative print:break-inside-avoid" style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 16px)' }}>
-      <div className="flex justify-between items-start mb-2">
+      <div className="flex justify-between items-start" style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 8px)' }}>
         <div className="flex-1 flex flex-wrap items-center gap-2">
           <h3 className="font-semibold text-gray-900 text-base">
             {project.name}
@@ -74,7 +74,7 @@ export function ProjectItem({ project, lineIndex }: { project: Project; lineInde
       </div>
 
       {(project.github_url || project.demo_url) && (
-        <div className="flex gap-4 text-sm text-blue-600 mb-2">
+        <div className="flex gap-4 text-sm text-blue-600" style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 8px)' }}>
           {project.github_url && (
             <a
               href={project.github_url}
@@ -101,17 +101,29 @@ export function ProjectItem({ project, lineIndex }: { project: Project; lineInde
       )}
 
       {project.overview && (
-        <p className="text-sm text-gray-600 mb-2 leading-relaxed">
+        <p
+          className="text-sm text-gray-600"
+          style={{
+            marginBottom: 'calc(var(--spacing-scale, 1) * 8px)',
+            lineHeight: 'calc(1.35 + var(--spacing-scale, 1) * 0.25)'
+          }}
+        >
           {project.overview}
         </p>
       )}
 
       {highlights.length > 0 && (
-        <div className="mb-2">
+        <div style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 8px)' }}>
           <span className="text-sm font-medium text-gray-700">关键亮点:</span>
-          <ul className="list-disc list-inside text-sm text-gray-600 mt-1">
+          <ul
+            className="list-disc list-inside text-sm text-gray-600"
+            style={{
+              marginTop: 'calc(var(--spacing-scale, 1) * 4px)',
+              lineHeight: 'calc(1.35 + var(--spacing-scale, 1) * 0.25)'
+            }}
+          >
             {highlights.map((achievement, achIndex) => (
-              <li key={achIndex}>{achievement}</li>
+              <li key={achIndex} style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 2px)' }}>{achievement}</li>
             ))}
           </ul>
         </div>

--- a/frontend/src/components/preview/sections/WorkExperiencePreview.tsx
+++ b/frontend/src/components/preview/sections/WorkExperiencePreview.tsx
@@ -24,7 +24,7 @@ export function WorkExperienceItem({ work, lineIndex }: { work: WorkExperience; 
 
   return (
     <div data-line-index={lineIndex} className="relative print:break-inside-avoid" style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 16px)' }}>
-      <div className="flex justify-between items-start mb-1.5">
+      <div className="flex justify-between items-start" style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 6px)' }}>
         <div className="flex-1 flex flex-wrap items-center gap-2">
           {work.company && (
             <h3 className="font-semibold text-gray-900 text-base">
@@ -46,10 +46,16 @@ export function WorkExperienceItem({ work, lineIndex }: { work: WorkExperience; 
       </div>
 
       {highlights.length > 0 && (
-        <div className="text-sm text-gray-600 mt-2 leading-relaxed">
+        <div
+          className="text-sm text-gray-600"
+          style={{
+            marginTop: 'calc(var(--spacing-scale, 1) * 8px)',
+            lineHeight: 'calc(1.35 + var(--spacing-scale, 1) * 0.25)'
+          }}
+        >
           <ul className="list-disc list-inside">
             {highlights.map((line, itemIndex) => (
-              <li key={itemIndex} className="mb-0.5">{line}</li>
+              <li key={itemIndex} style={{ marginBottom: 'calc(var(--spacing-scale, 1) * 2px)' }}>{line}</li>
             ))}
           </ul>
         </div>

--- a/frontend/src/components/ui/MarkdownMessage.tsx
+++ b/frontend/src/components/ui/MarkdownMessage.tsx
@@ -40,18 +40,18 @@ export default function MarkdownMessage({ content, className = '' }: MarkdownMes
         components={{
           // 自定义标题样式
           h1: ({ children }) => (
-            <h1 className="text-xl font-bold mb-3 text-gray-900">{children}</h1>
+            <h1 className="text-[18px] font-bold mb-3 text-gray-900">{children}</h1>
           ),
           h2: ({ children }) => (
-            <h2 className="text-lg font-semibold mb-2 text-gray-800">{children}</h2>
+            <h2 className="text-[16px] font-semibold mb-2 text-gray-800">{children}</h2>
           ),
           h3: ({ children }) => (
-            <h3 className="text-base font-medium mb-2 text-gray-700">{children}</h3>
+            <h3 className="text-[15px] font-medium mb-2 text-gray-700">{children}</h3>
           ),
           
           // 自定义段落样式
           p: ({ children }) => (
-            <p className="mb-3 leading-relaxed text-sm text-gray-700 last:mb-0">{children}</p>
+            <p className="mb-3 leading-relaxed text-[14px] text-gray-700 last:mb-0">{children}</p>
           ),
           
           // 自定义列表样式
@@ -62,7 +62,7 @@ export default function MarkdownMessage({ content, className = '' }: MarkdownMes
             <ol className="mb-3 ml-4 space-y-1 list-decimal">{children}</ol>
           ),
           li: ({ children }) => (
-            <li className="text-sm text-gray-700 leading-relaxed">{children}</li>
+            <li className="text-[14px] text-gray-700 leading-relaxed">{children}</li>
           ),
           
           // 自定义强调样式

--- a/frontend/src/components/ui/StreamingMessage.tsx
+++ b/frontend/src/components/ui/StreamingMessage.tsx
@@ -18,13 +18,13 @@ export default function StreamingMessage({
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          h1: ({ children }) => <h1 className="text-xl font-bold text-gray-900 mb-3">{children}</h1>,
-          h2: ({ children }) => <h2 className="text-lg font-semibold text-gray-900 mb-2">{children}</h2>,
-          h3: ({ children }) => <h3 className="text-base font-medium text-gray-900 mb-2">{children}</h3>,
-          p: ({ children }) => <p className="text-sm text-gray-700 mb-2 last:mb-0">{children}</p>,
-          ul: ({ children }) => <ul className="list-disc list-inside text-sm text-gray-700 mb-2 space-y-1">{children}</ul>,
-          ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-gray-700 mb-2 space-y-1">{children}</ol>,
-          li: ({ children }) => <li className="text-sm">{children}</li>,
+          h1: ({ children }) => <h1 className="text-[18px] font-bold text-gray-900 mb-3">{children}</h1>,
+          h2: ({ children }) => <h2 className="text-[16px] font-semibold text-gray-900 mb-2">{children}</h2>,
+          h3: ({ children }) => <h3 className="text-[15px] font-medium text-gray-900 mb-2">{children}</h3>,
+          p: ({ children }) => <p className="text-[14px] text-gray-700 mb-2 last:mb-0">{children}</p>,
+          ul: ({ children }) => <ul className="list-disc list-inside text-[14px] text-gray-700 mb-2 space-y-1">{children}</ul>,
+          ol: ({ children }) => <ol className="list-decimal list-inside text-[14px] text-gray-700 mb-2 space-y-1">{children}</ol>,
+          li: ({ children }) => <li className="text-[14px]">{children}</li>,
           code: ({ children, ...props }) => 
             (props as any).inline ? (
               <code className="bg-gray-100 text-gray-800 px-1 py-0.5 rounded text-xs font-mono">
@@ -37,7 +37,7 @@ export default function StreamingMessage({
             ),
           pre: ({ children }) => <pre className="bg-gray-100 p-3 rounded-lg overflow-x-auto mb-2">{children}</pre>,
           blockquote: ({ children }) => (
-            <blockquote className="border-l-4 border-gray-300 pl-4 py-2 bg-gray-50 text-sm text-gray-600 mb-2 rounded-r">
+            <blockquote className="border-l-4 border-gray-300 pl-4 py-2 bg-gray-50 text-[14px] text-gray-600 mb-2 rounded-r">
               {children}
             </blockquote>
           ),


### PR DESCRIPTION
## Summary

Refines the resume editor and preview UI based on recent review feedback:

- isolates SmartFit measurement from pagination measurement so trial spacing no longer mutates the official pagination container
- extends spacing controls into resume section internals such as work, project, and education bullet content
- simplifies the layout settings panel by merging display and ordering controls, removing extra helper copy, and removing redundant icons
- adjusts header actions, skill chip sizing, project helper text, and chat message typography

## Validation

- Ran targeted TypeScript checks for preview section changes successfully.
- Ran `npm run type-check` from `frontend`; it failed because existing Playwright dependencies/types are missing for `@playwright/test` in `e2e/*.spec.ts` and `playwright.config.ts`. No failures were reported in the modified UI files by that full-project run.

## Notes

Untracked workflow/documentation files (`AGENTS.md`, `docs/contracts/...`, `docs/evaluators/`, `docs/prompt/`) were intentionally left out of this PR.