### PR TITLE
Add centralized httpClient and migrate API calls to `apiUrl`/`apiFetch`/`handleApiResponse`

### DIFF
--- a/frontend/src/app/[locale]/settings/page.tsx
+++ b/frontend/src/app/[locale]/settings/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@heroicons/react/24/outline'
 import toast from 'react-hot-toast'
 import { billingApi, type BillingStatus, type PayPalPlan } from '@/lib/api'
+import { apiFetch, handleApiResponse } from '@/lib/httpClient'
 import { useTranslations } from 'next-intl'
 
 // 用于格式化套餐卡片价格。
@@ -138,20 +139,15 @@ export default function SettingsPage() {
     }
     setIsLoading(true)
     try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/auth/me`,
-        {
-          method: 'PUT',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ full_name: userSettings.fullName.trim() })
-        }
+      const response = await apiFetch('/api/auth/me', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ full_name: userSettings.fullName.trim() })
+      })
+      const updatedUser = await handleApiResponse<{ full_name?: string; email?: string }>(
+        response,
+        t('settings.saveFallback')
       )
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}))
-        throw new Error(errorData.detail || t('settings.saveFallback'))
-      }
-      const updatedUser = await response.json()
       setUserSettings({ fullName: updatedUser.full_name || '', email: updatedUser.email || '' })
       updateUser(updatedUser)
       toast.success(t('settings.saveSuccess'))
@@ -174,22 +170,15 @@ export default function SettingsPage() {
     }
     setIsPasswordSaving(true)
     try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/auth/change-password`,
-        {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            current_password: passwordSettings.currentPassword,
-            new_password: passwordSettings.newPassword,
-          })
-        }
-      )
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}))
-        throw new Error(errorData.detail || t('settings.passwordSaveFallback'))
-      }
+      const response = await apiFetch('/api/auth/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          current_password: passwordSettings.currentPassword,
+          new_password: passwordSettings.newPassword,
+        })
+      })
+      await handleApiResponse(response, t('settings.passwordSaveFallback'))
       setPasswordSettings({ currentPassword: '', newPassword: '', confirmPassword: '' })
       toast.success(t('settings.passwordSaveSuccess'))
     } catch (error) {

--- a/frontend/src/components/auth/GoogleContinueLink.tsx
+++ b/frontend/src/components/auth/GoogleContinueLink.tsx
@@ -2,12 +2,11 @@
 // 用于提供 components/auth/GoogleContinueLink.tsx 模块。
 
 import { useTranslations } from 'next-intl'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+import { apiUrl } from '@/lib/httpClient'
 
 // 用于获取Google登录地址。
 export function getGoogleLoginUrl() {
-  return `${API_BASE_URL}/api/auth/google/login`
+  return apiUrl('/api/auth/google/login')
 }
 
 // 用于渲染 GoogleContinueLink 组件。

--- a/frontend/src/lib/httpClient.ts
+++ b/frontend/src/lib/httpClient.ts
@@ -1,9 +1,16 @@
 // 用于提供 lib/httpClient.ts 模块。
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
+// 用于安全拼接 API 地址，避免重复或缺失斜杠。
+function joinApiUrl(baseUrl: string, path: string): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, '')
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${normalizedBase}${normalizedPath}`
+}
+
 // 用于处理API地址。
 export function apiUrl(path: string, baseUrl = API_BASE_URL): string {
-  return `${baseUrl}${path}`
+  return joinApiUrl(baseUrl, path)
 }
 
 // 统一通过 HttpOnly Cookie 发起带登录态的请求。
@@ -26,11 +33,11 @@ export async function fetchWithTimeout(
   baseUrl = API_BASE_URL,
 ) {
   const controller = new AbortController()
-  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs)
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
   try {
     return await apiFetch(path, { ...init, signal: controller.signal }, baseUrl)
   } finally {
-    window.clearTimeout(timeoutId)
+    clearTimeout(timeoutId)
   }
 }
 

--- a/frontend/src/lib/resumeLayoutConfig.ts
+++ b/frontend/src/lib/resumeLayoutConfig.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ModuleConfig, ResumeModule, ResumeTemplateStyle } from '@/types/resumeLayout'
+import { apiUrl } from '@/lib/httpClient'
 
 export type { ModuleConfig, ResumeModule, ResumeTemplateStyle } from '@/types/resumeLayout'
 
@@ -94,7 +95,6 @@ export const DEFAULT_LAYOUT_CONFIG: ResumeLayoutConfig = {
   templateStyle: 'classic',
 }
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
 /**
  * 将服务端返回的 layout_config 原始对象转换为 ResumeLayoutConfig
@@ -168,7 +168,7 @@ export async function saveLayoutConfigToServer(resumeId: number, config: ResumeL
   // 同步更新本地缓存
   saveLayoutConfig(resumeId, config)
 
-  await fetch(`${API_BASE_URL}/api/resumes/${resumeId}/layout`, {
+  await fetch(apiUrl(`/api/resumes/${resumeId}/layout`), {
     method: 'PUT',
     credentials: 'include',
     headers: {

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -3,8 +3,7 @@ import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import createIntlProxy from 'next-intl/middleware'
 import { isAppLocale, routing } from './i18n/routing'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+import { apiUrl } from '@/lib/httpClient'
 const PROTECTED_PREFIXES = ['/dashboard', '/settings', '/interviews', '/resume', '/resumes']
 const PUBLIC_PATHS = new Set(['/login', '/register', '/', '/resume/print'])
 const intlProxy = createIntlProxy(routing)
@@ -12,7 +11,7 @@ const intlProxy = createIntlProxy(routing)
 // 这里通过后端 /auth/me 校验 token 真伪，避免只凭 cookie 存在就放行受保护页面。
 async function hasValidSession(accessToken: string): Promise<boolean> {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/auth/me`, {
+    const response = await fetch(apiUrl('/api/auth/me'), {
       headers: { Authorization: `Bearer ${accessToken}` },
       cache: 'no-store',
     })


### PR DESCRIPTION
### Motivation

- Consolidate API URL construction, fetch semantics (credentials, timeouts) and error handling to reduce duplicated logic and inconsistent behaviors across the frontend.

### Description

- Add `frontend/src/lib/httpClient.ts` with `apiUrl`, `apiFetch`, `fetchWithTimeout`, `handleApiResponse`, and a safe `joinApiUrl` implementation to normalize base/path joining and improve error messages.
- Replace inline usage of `process.env.NEXT_PUBLIC_API_URL` and ad-hoc `fetch` calls with `apiUrl`/`apiFetch` in `settings/page.tsx`, moving responses through `handleApiResponse` for consistent error handling and response parsing.
- Update `components/auth/GoogleContinueLink.tsx` to generate Google OAuth URL via `apiUrl` instead of manually composing the base URL.
- Update `resumeLayoutConfig.ts` to use `apiUrl` for saving layout config to server and avoid duplicated base URL constants.
- Update `proxy.ts` to use `apiUrl` when checking session validity with `/api/auth/me` and remove a duplicated base URL constant.
- Minor robustness fixes in `httpClient.ts` including normalized `setTimeout`/`clearTimeout` usage.

### Testing

- Ran TypeScript type-check (`tsc`) against the frontend and it succeeded.
- Ran the frontend test suite (`npm test`) and the tests passed.
- Ran ESLint (`npm run lint`) to verify code style and no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09be7b60e883278661a0ee3c13b304)