### PR TITLE
Fix fetchWithTimeout for non-window runtimes and add regression check

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "type-check": "tsc --noEmit -p tsconfig.typecheck.json",
     "perf:prod": "node scripts/measure-production.mjs",
     "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui"
+    "e2e:ui": "playwright test --ui",
+    "check:http-client-no-window": "node --experimental-strip-types scripts/httpClient-no-window-check.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",

--- a/frontend/scripts/httpClient-no-window-check.mjs
+++ b/frontend/scripts/httpClient-no-window-check.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+
+// 用于在无 window 环境验证 fetchWithTimeout 超时行为。
+globalThis.fetch = async (_url, init = {}) => {
+  await new Promise((resolve, reject) => {
+    if (init.signal) {
+      init.signal.addEventListener('abort', () => {
+        const error = new Error('The operation was aborted')
+        error.name = 'AbortError'
+        reject(error)
+      })
+    }
+  })
+}
+
+const { fetchWithTimeout } = await import('../src/lib/httpClient.ts')
+
+let caughtError
+try {
+  await fetchWithTimeout('/health', {}, 5, 'http://localhost:8000')
+} catch (error) {
+  caughtError = error
+}
+
+assert.ok(caughtError instanceof Error)
+assert.match(caughtError.message, /API请求超时/)
+assert.match(caughtError.message, /\/health/)
+assert.match(caughtError.message, /5ms/)
+
+console.log('fetchWithTimeout no-window check passed')

--- a/frontend/src/lib/httpClient.ts
+++ b/frontend/src/lib/httpClient.ts
@@ -26,11 +26,16 @@ export async function fetchWithTimeout(
   baseUrl = API_BASE_URL,
 ) {
   const controller = new AbortController()
-  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs)
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
   try {
     return await apiFetch(path, { ...init, signal: controller.signal }, baseUrl)
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`API请求超时: ${path} (${timeoutMs}ms)`)
+    }
+    throw error
   } finally {
-    window.clearTimeout(timeoutId)
+    clearTimeout(timeoutId)
   }
 }
 


### PR DESCRIPTION
### Motivation

- Ensure `fetchWithTimeout` works in Node-like runtimes where `window` is not defined to avoid `window is not defined` errors. 
- Preserve the existing `AbortController` cancellation behavior while surfacing a readable timeout error. 
- Add a minimal regression check to catch regressions in environments without `window`.

### Description

- Replaced `window.setTimeout` / `window.clearTimeout` with global `setTimeout` / `clearTimeout` in `frontend/src/lib/httpClient.ts` and wrapped timeout aborts into a readable error `API请求超时: <path> (<timeoutMs>ms)` when the controller was aborted. 
- Kept the `AbortController` signal wired to `apiFetch` so original cancellation semantics remain intact. 
- Added a small Node-based validation script `frontend/scripts/httpClient-no-window-check.mjs` that mocks `fetch` in a no-`window` environment and asserts the timeout error contains the path and timeout, and added an npm script `check:http-client-no-window` to run it in `frontend/package.json`.

### Testing

- Ran `npm run check:http-client-no-window` which executes the Node validation script and it passed. 
- Ran `npm run type-check` which failed due to existing TypeScript deprecation warnings (`TS5101` / `TS5107`) in the project config and is unrelated to this change. 
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09bfc41dd08327a91658115c0ecb2d)